### PR TITLE
Some changes to jira-omnifocus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gem 'json'
 gem 'trollop'
 gem 'jira-ruby', :git => 'https://github.com/sumoheavy/jira-ruby.git'
 gem 'highline'
-
+gem 'ruby-keychain', :require => 'keychain'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,12 +15,18 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    corefoundation (0.2.0)
+      ffi
+    ffi (1.9.10)
     highline (1.6.21)
     i18n (0.6.11)
     json (1.8.1)
     minitest (5.4.0)
     oauth (0.4.7)
     rb-appscript (0.6.1)
+    ruby-keychain (0.3.2)
+      corefoundation (~> 0.2.0)
+      ffi
     thread_safe (0.3.4)
     trollop (2.0)
     tzinfo (1.2.2)
@@ -34,4 +40,8 @@ DEPENDENCIES
   jira-ruby!
   json
   rb-appscript
+  ruby-keychain
   trollop
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ http://www.digitalsanctuary.com/tech-blog/general/jira-to-omnifocus-integration.
 
 What it does:
 
-It pulls back all unresolved Jira tickets that are assigned to you and if it hasn't already created a OmniFocus task for that ticket, it creates a new one.  The title of the task is the Jira ticket number followed by the summary from the ticket.  The note part of the OmniFocus task will contain the URL to the Jira ticket so you can easily go right to it.  I chose not to pull over the full description, or comment history into the task notes as it's usually more than I want to see in OmniFocus.
+It pulls back all unresolved Jira tickets that you are watching and if it hasn't already created a OmniFocus task for that ticket, it creates a new one.  The title of the task is the Jira ticket number followed by the summary from the ticket.  The note part of the OmniFocus task will contain the URL to the Jira ticket so you can easily go right to it.  I chose not to pull over the full description, or comment history into the task notes as it's usually more than I want to see in OmniFocus. If the ticket is assigned to you, it will be flagged. The context will be set based on who generated the ticket.  If there is no existing context, one will be created.
 
-It also checks all the OmniFocus tasks that look like they are related to Jira tickets, and checks to see if the matching ticket has been resolved.  If so, it marks the task as complete. If a task has been re-assigned to someone else or unassigned it will remove it from Omnifocus.
+It also checks all the OmniFocus tasks that look like they are related to Jira tickets, and checks to see if the matching ticket has been resolved.  If so, it marks the task as complete. If a task has been re-assigned to someone else or unassigned it will no longer be flagged.
 
 Very simple.  The Ruby code is straight forward and it should be easy to modify to do other things to meet your specific needs.
 
@@ -20,11 +20,11 @@ gem install bundler
 bundle install
 ```
 
-This also support [rbenv](http://rbenv.org/), if you happen to be using it.
+This also supports [rbenv](http://rbenv.org/), if you happen to be using it.
 
-You'll need to copy jofsync.yaml.sample from the git checkout to ~/.jofsync.yaml, and then edit is as appropriate.
+You'll need to copy jofsync.yaml.sample from the git checkout to ~/.jofsync.yaml, and then edit it as appropriate.
 
-Make sure that you have a project in context in Omnifocus that matches what you used in the configuration file.
+Make sure that you have a project and context in OmniFocus that match what you used in the configuration file.
 
 You can run the script manually or you can add a cron entry to run it periodically (it will take a minute or so to run so don't run it too often).
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Make sure that you have a project and context in OmniFocus that match what you u
 
 Your username and password for the Jira server must be defined in your keychain. Unlike previous versions of this script, your password is not stored in plain text.
 
-You can run the script manually or you can add a cron entry to run it periodically (it will take a minute or so to run so don't run it too often).
+This version of jofsync will not run under cron and instead needs to be run under launchd.  This is because it requires access to the keychain in lieu of hardcoded passwords.
 
-You can use crontab -e to edit your user crontab and create an entry like this:
+To install it in launchd, edit jofsync.plist to meet your needs and copy it to ~/Library/LaunchAgents/jofsync.plist and run
 
 ```
-*/10 * * * * cd ~/dev/git/jira-omnifocus/bin && ./jiraomnifocus.rb
+launchctl load ~/Library/LaunchAgents/jofsync.plist
 ```
 
 That should be it!  If it doesn't work, try adding some puts debug statements and running it manually.  

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ You'll need to copy jofsync.yaml.sample from the git checkout to ~/.jofsync.yaml
 
 Make sure that you have a project and context in OmniFocus that match what you used in the configuration file.
 
+Your username and password for the Jira server must be defined in your keychain. Unlike previous versions of this script, your password is not stored in plain text.
+
 You can run the script manually or you can add a cron entry to run it periodically (it will take a minute or so to run so don't run it too often).
 
 You can use crontab -e to edit your user crontab and create an entry like this:

--- a/bin/jiraomnifocus.rb
+++ b/bin/jiraomnifocus.rb
@@ -173,7 +173,8 @@ def add_jira_tickets_to_omnifocus ()
     @props = {}
     @props['name'] = task_name
     @props['project'] = DEFAULT_PROJECT
-    @props['context'] = ticket["fields"]["reporter"]["name"]
+#   @props['context'] = ticket["fields"]["reporter"]["displayName"]
+    @props['context'] = ticket["fields"]["reporter"]["displayName"].split(", ").reverse.join(" ")
     @props['note'] = task_notes
     # Flag the task iff it's assigned to me.
     @props['flagged'] = (ticket["fields"]["assignee"]["name"] == USERNAME)

--- a/bin/jiraomnifocus.rb
+++ b/bin/jiraomnifocus.rb
@@ -11,7 +11,7 @@ require 'keychain'
 opts = Trollop::options do
   banner ""
   banner <<-EOS
-Jira Omnifocus Sync Tool
+Jira OmniFocus Sync Tool
 
 Usage:
        jofsync [options]
@@ -79,7 +79,7 @@ JQL = URI::encode(QUERY)
 DEFAULT_CONTEXT = opts[:context]
 DEFAULT_PROJECT = opts[:project]
 
-# This method gets all issues that are assigned to your USERNAME and whos status isn't Closed or Resolved.  It returns a Hash where the key is the Jira Ticket Key and the value is the Jira Ticket Summary.
+# This method gets all issues that you are watching and whose resolution is Unresolved.  It returns a Hash where the key is the Jira Ticket Key and the value is the Jira Ticket Summary.
 def get_issues
   jira_issues = Hash.new
   # This is the REST URL that will be hit.  Change the jql query if you want to adjust the query used here

--- a/bin/jiraomnifocus.rb
+++ b/bin/jiraomnifocus.rb
@@ -26,7 +26,6 @@ EOS
   opt :hostname, 'Jira Server Hostname', :type => :string, :short => 'h', :required => false
   opt :context, 'OF Default Context', :type => :string, :short => 'c', :required => false
   opt :project, 'OF Default Project', :type => :string, :short => 'r', :required => false
-  opt :flag, 'Flag tasks in OF', :type => :boolean, :short => 'f', :required => false
   opt :filter, 'JQL Filter', :type => :string, :short => 'j', :required => false
   opt :quiet, 'Disable terminal output', :short => 'q', :default => true
 end
@@ -52,12 +51,11 @@ jira:
   password: 'blahblahblah'
   context: 'Jira'
   project: 'Work'
-  flag: true
   filter: 'assignee = currentUser() AND status not in (Closed, Resolved) AND sprint in openSprints()'
 =end
 end
 
-syms = [:username, :hostname, :context, :project, :flag, :filter]
+syms = [:username, :hostname, :context, :project, :filter]
 syms.each { |x|
   unless opts[x]
     if config[:jira][x]
@@ -88,7 +86,6 @@ JQL = URI::encode(QUERY)
 #OmniFocus Configuration
 DEFAULT_CONTEXT = opts[:context]
 DEFAULT_PROJECT = opts[:project]
-FLAGGED = opts[:flag]
 
 # This method gets all issues that are assigned to your USERNAME and whos status isn't Closed or Resolved.  It returns a Hash where the key is the Jira Ticket Key and the value is the Jira Ticket Summary.
 def get_issues

--- a/bin/jiraomnifocus.rb
+++ b/bin/jiraomnifocus.rb
@@ -177,7 +177,7 @@ def add_jira_tickets_to_omnifocus ()
     @props['context'] = ticket["fields"]["reporter"]["displayName"].split(", ").reverse.join(" ")
     @props['note'] = task_notes
     # Flag the task iff it's assigned to me.
-    @props['flagged'] = (ticket["fields"]["assignee"]["name"] == USERNAME)
+    @props['flagged'] = (not ticket["fields"]["assignee"].nil? and (ticket["fields"]["assignee"]["name"] == USERNAME))
     unless ticket["fields"]["duedate"].nil?
       @props["due_date"] = Date.parse(ticket["fields"]["duedate"])
     end
@@ -206,8 +206,8 @@ def mark_resolved_jira_tickets_as_complete_in_omnifocus ()
         if response.code =~ /20[0-9]{1}/
           data = JSON.parse(response.body)
           # Check to see if the Jira ticket has been resolved, if so mark it as complete.
-          resolution = data["fields"]["resolution"]
-          if resolution != nil
+          status = data["fields"]["status"]
+          if ['Closed', 'Resolved'].include? status
             # if resolved, mark it as complete in OmniFocus
             if task.completed.get != true
               task.completed.set(true)

--- a/bin/jiraomnifocus.rb
+++ b/bin/jiraomnifocus.rb
@@ -49,9 +49,9 @@ jira:
   hostname: 'http://example.atlassian.net'
   username: 'jdoe'
   password: 'blahblahblah'
-  context: 'Jira'
-  project: 'Work'
-  filter: 'assignee = currentUser() AND status not in (Closed, Resolved) AND sprint in openSprints()'
+  context:  'Colleagues'
+  project:  'Jira'
+  filter:   'resolution = Unresolved and issue in watchedissues()'
 =end
 end
 

--- a/bin/jiraomnifocus.rb
+++ b/bin/jiraomnifocus.rb
@@ -177,7 +177,7 @@ def add_jira_tickets_to_omnifocus ()
     @props['context'] = ticket["fields"]["reporter"]["displayName"].split(", ").reverse.join(" ")
     @props['note'] = task_notes
     # Flag the task iff it's assigned to me.
-    @props['flagged'] = (not ticket["fields"]["assignee"].nil? and (ticket["fields"]["assignee"]["name"] == USERNAME))
+    @props['flagged'] = ((not ticket["fields"]["assignee"].nil?) and (ticket["fields"]["assignee"]["name"] == USERNAME))
     unless ticket["fields"]["duedate"].nil?
       @props["due_date"] = Date.parse(ticket["fields"]["duedate"])
     end

--- a/jofsync.plist
+++ b/jofsync.plist
@@ -13,9 +13,5 @@
       <integer>300</integer>
     <key>Debug</key>
       <false/>
-    <key>AbandonProcessGroup</key>
-      <true/>
-    <key>ProcessType</key>
-      <string>Interactive</string>
   </dict>
 </plist>

--- a/jofsync.plist
+++ b/jofsync.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" \
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+      <string>jofsync</string>
+    <key>WorkingDirectory</key>
+      <string>/Users/cgarrigues/GitHub/jira-omnifocus/bin</string>
+    <key>Program</key>
+      <string>./jiraomnifocus.rb</string>
+    <key>StartInterval</key>
+      <integer>300</integer>
+    <key>Debug</key>
+      <false/>
+    <key>AbandonProcessGroup</key>
+      <true/>
+    <key>ProcessType</key>
+      <string>Interactive</string>
+  </dict>
+</plist>

--- a/jofsync.yaml.sample
+++ b/jofsync.yaml.sample
@@ -3,4 +3,4 @@ jira:
   hostname: 'http://example.atlassian.net'
   context:  'Office'
   project:  'Jira'
-  filter:   'resolution = Unresolved and issue in watchedissues()'
+  filter:   'status != Closed and status != Resolved and issue in watchedissues()'

--- a/jofsync.yaml.sample
+++ b/jofsync.yaml.sample
@@ -5,5 +5,4 @@ jira:
   password: 'secret'
   context:  'Office'
   project:  'Jira'
-  flag:     true
-  filter:   'assignee = currentUser() AND status not in (Closed, Resolved)'
+  filter:   'resolution = Unresolved and issue in watchedissues()'

--- a/jofsync.yaml.sample
+++ b/jofsync.yaml.sample
@@ -1,8 +1,6 @@
 ---
 jira:
   hostname: 'http://example.atlassian.net'
-  username: 'me'
-  password: 'secret'
   context:  'Office'
   project:  'Jira'
   filter:   'resolution = Unresolved and issue in watchedissues()'


### PR DESCRIPTION
I made several changes (improvements?) to jira-omnifocus.

First, I changed the semantics to match my needs.  I often work on tickets that aren't actually assigned to me, so instead of just pulling my assigned tickets, I pull all tickets that I'm watching.  This includes ones that are assigned to me.  I then flag those that are actually assigned to me. I hope these semantics are useful for others besides myself.

Second, I set the context based on who requested the ticket as I have to work closely with the requestor.  The contexts are sub contexts of "Colleagues" in my case.

Third, putting a password in a plain text file is a bad idea, so I use the keychain instead to retrieve both the user and the password.  This will not work if the job runs under cron, so I figured out how to run it under launchd instead and documented that.

I've been running this for a few weeks and haven't touched the code since last week, so I think it's pretty much where it needs to be.