### PR TITLE
Allow --help to work without config, better error

### DIFF
--- a/bin/jiraomnifocus.rb
+++ b/bin/jiraomnifocus.rb
@@ -12,11 +12,11 @@ require 'pathname'
 def get_opts
   if  File.file?(ENV['HOME']+'/.jofsync.yaml')
     config = YAML.load_file(ENV['HOME']+'/.jofsync.yaml')
-=begin
-YAML CONFIG EXAMPLE
+  else config = YAML.load <<-EOS
+#YAML CONFIG EXAMPLE
 ---
 jira:
-  hostname: 'http://example.atlassian.net'
+  hostname: 'http://please-configure-me-in-jofsync.yaml.atlassian.net'
   keychain: false
   username: ''
   password: ''
@@ -25,7 +25,7 @@ omnifocus:
   context:  'Office'
   project:  'Jira'
   flag: true
-=end
+EOS
   end
 
   return Trollop::options do


### PR DESCRIPTION
So me, being the gung-ho type that I am, downloaded this and ran it immediately without bothering to read the docs. This resulted in the old fashioned "[] on a nil class" error. I thought something was broken, so I tried running the program with --help, which gave the same problem. This is since the "config" var is only defined if a file exists (which causes Trollop to break when trying to parse the default options).

This changes the example from a block comment to inline YAML, and changes the URL, causing an HTTP error that will clue the user in that something's amiss if they just run the app, indicating that they need to configure it (and as a bonus, allows --help to work even if the config file doesn't exist).