### PR TITLE
Task creation options now set in config file

### DIFF
--- a/jofsync.yaml.sample
+++ b/jofsync.yaml.sample
@@ -6,6 +6,9 @@ jira:
   password: 'secret'
   filter:   'assignee = currentUser() AND status not in (Closed, Resolved)'
 omnifocus:
-  context:  'Office'
-  project:  'Jira'
-  flag:     true
+  context:  'Office'   # The default OF Context where new tasks are created.
+  project:  'Jira'     # The default OF Project where new tasks are created.
+  flag:     true       # Set this to 'true' if you want the new tasks to be flagged.
+  inbox:    false      # Set 'true' if you want tasks in the Inbox instead of in a specific project.
+  newproj:  false      # Set 'true' to add each JIRA ticket to OF as a Project instead of a Task.
+  folder:   'Jira'     # Sets the OF folder where new Projects are created (only applies if 'newproj' is 'true').


### PR DESCRIPTION
We had a couple of options that were configured by commenting and un-commenting various lines in the script; I've moved these options to the YAML config file. 

There are now three options for task creation:
- Create the tasks in a specific Project and Context
- Create the tasks in the OmniFocus Inbox
- Create each task as a separate Project in a specified Folder (I like and use this option)

Also, when checking to see if a JIRA ticket already has a related Task, the script will search your entire OF document if you are using the 'inbox' or 'newproj' option; if you are storing all your JIRA tasks in one Project, the script will only search there. 

Also added some comments to the jofsync.yaml.sample file to describe what the options will do.