### PR TITLE
Added local development folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .project
+.idea
+.bundle
+vendor


### PR DESCRIPTION
Fixes #34 by adding the relevant folders to .gitignore
Nobody ever wants to check them in, so it should be safe to do.