### PR TITLE
https://github.com/devondragon/jira-omnifocus/issues/56

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ http://www.digitalsanctuary.com/tech-blog/general/jira-to-omnifocus-integration.
 
 ## What it does:
 
-It pulls back all unresolved JIRA tickets that are assigned to you and if it hasn't already created a OmniFocus task for that ticket, it creates a new one.  The title of the task is the JIRA ticket number followed by the summary from the ticket.  The note part of the OmniFocus task will contain the URL to the JIRA ticket so you can easily go right to it.  I chose not to pull over the comment history into the task notes as it's usually more than I want to see in OmniFocus.
+It pulls back all unresolved JIRA tickets that are assigned to you and if it hasn't already created a OmniFocus task for that ticket, it creates a new one. The title of the task is the JIRA ticket number followed by the summary from the ticket. The note part of the OmniFocus task will contain the URL to the JIRA ticket so you can easily go right to it. I chose not to pull over the comment history into the task notes as it's usually more than I want to see in OmniFocus.
 
-It also checks all the OmniFocus tasks that look like they are related to JIRA tickets, and checks to see if the matching ticket has been resolved.  If so, it marks the task as complete. If a task has been re-assigned to someone else or unassigned it will remove it from OmniFocus.
+It also checks all the OmniFocus tasks that look like they are related to JIRA tickets, and checks to see if the matching ticket has been resolved. If so, it marks the task as complete. If a task has been re-assigned to someone else or unassigned it will remove it from OmniFocus.
 
-Very simple.  The Ruby code is straight forward and it should be easy to modify to do other things to meet your specific needs.
+Very simple. The Ruby code is straight forward and it should be easy to modify to do other things to meet your specific needs.
 
 ## Dependencies
+
 This project expect you have a Ruby development environment installed, and also supports [rbenv](http://rbenv.org/), if you happen to be using it.
 
 jira-omnifocus also uses [Bundler](http://bundler.io/), so you will need to install it.
@@ -42,6 +43,7 @@ cp jofsync.yaml.sample ~/.jofsync.yaml
 In ~/.jofsync.yaml, you'll find various options for configuring your connection to JIRA, and specifying how and where you would like to categorize issues in OmniFocus as they are added by the script.
 
 #### `jira` configuration options
+
 **`hostname`**
 The URL of your JIRA project. Make sure to specify `https` if your project requires it.
 
@@ -53,12 +55,13 @@ security add-internet-password -a <username> -s <hostname> -w <password>
 ```
 
 **`username` and `password`**
-Username needs be set to your actual username, NOT your email address.  You only need to set the password if you've set `keychain` to `false`.  If you are using the new api_token for JIRA, just put the token in as the password.
+Username needs be set to your actual username, NOT your email address. You only need to set the password if you've set `keychain` to `false`. If you are using the new api_token for JIRA, just put the token in as the password.
 
 **`filter`**
 This is the JQL (JIRA's custom query language) command jira-omnifocus will use to find issues.
 
 #### `omnifocus` configuration options
+
 **`tag`**
 The default OmniFocus tag assigned to new tasks. Make sure this context exists in OmniFocus. Leave this blank if you'd prefer not to set a context.
 
@@ -74,36 +77,40 @@ Set this option to `true` if you want tasks added to the inbox instead of in a s
 **`newproj`**
 Set this option to `true` to add each JIRA ticket to OmniFocus as a project instead of a task. Leave `project` blank and set `inbox` to `false` if this option is set to `true`.
 
+**`descsync`**
+Set this option to `true` if you want JIRA task descriptions synced to OF task notes.
+
 **`folder`**
 Sets the OmniFocus folder where new projects are created if `newproj` is `true`. Make sure this folder exists in OmniFocus.
 
 ### Running the script
 
-You can run the script manually with `bundle exec bin/jiraomnifocus.rb`, use OS X's `launchd` to schedule it (this is preferred), or add a cron entry to run it periodically (it will take a minute or so to run so don't run it too often).  If you are using the keychain option, you MUST use the `launchd` scheduler instead of `cron`.
+You can run the script manually with `bundle exec bin/jiraomnifocus.rb`, use OS X's `launchd` to schedule it (this is preferred), or add a cron entry to run it periodically (it will take a minute or so to run so don't run it too often). If you are using the keychain option, you MUST use the `launchd` scheduler instead of `cron`.
 
 #### If you have SSL Connection errors
 
-This is due to an older version of Ruby not supporting modern cipher suites.  In order to fix this on my Mac (running macOS Sierra 10.12.6) I used rbenv to install ruby 2.1.2, and then I set it to be the global default (you don't have to do this if you change how you launch the script, etc...):
+This is due to an older version of Ruby not supporting modern cipher suites. In order to fix this on my Mac (running macOS Sierra 10.12.6) I used rbenv to install ruby 2.1.2, and then I set it to be the global default (you don't have to do this if you change how you launch the script, etc...):
 
 ```
 rbenv install 2.1.2
 rbenv global 2.1.2
 ```
 
-This solved my SSL Connection errors!  At least when running the script manually, there was still something I had to do to make the launchd solution below work, so please read the section below in detail.
-
+This solved my SSL Connection errors! At least when running the script manually, there was still something I had to do to make the launchd solution below work, so please read the section below in detail.
 
 #### Running automatically with `launchd`
+
 To install it in launchd, copy jofsync.plist to ~/Library/LaunchAgents/jofsync.plist
 
 ```
 cp jofsync.plist ~/Library/LaunchAgents/jofsync.plist
 ```
 
-Edit `~/Library/LaunchAgents/jofsync.plist` to meet your needs. The `WorkingDirectory` and second `ProgramArguments` strings must be set. You can optionally change the `Label` or `StartInterval`. 
+Edit `~/Library/LaunchAgents/jofsync.plist` to meet your needs. The `WorkingDirectory` and second `ProgramArguments` strings must be set. You can optionally change the `Label` or `StartInterval`.
 
 **`WorkingDirectory`**
 Replace the value of `<string>` with the path to your local clone of the project's `bin`.
+
 ```
 <key>WorkingDirectory</key>
   <string>/Users/your-username/path/to/local/clone/jira-omnifocus/bin</string>
@@ -120,14 +127,13 @@ Replace the value of the second `<string>` argument with the path to your local 
   </array>
 ```
 
-Please note that if you had to install a newer version of ruby, such as 2.1.2 in the above section about SSL Connection errors, when launchd runs the script it will not respect your user rbenv settings.  So I edited the ProgramArguments above and changed the path for ruby to:
+Please note that if you had to install a newer version of ruby, such as 2.1.2 in the above section about SSL Connection errors, when launchd runs the script it will not respect your user rbenv settings. So I edited the ProgramArguments above and changed the path for ruby to:
 
 ```
 /Users/your-username/.rbenv/shims/ruby
 ```
 
 Which forced the scheduled launchd script to use the ruby 2.1.2 version.
-
 
 **`StartInterval`**
 Replace the integer value to change the time in seconds that controls how often the script will run.
@@ -136,9 +142,6 @@ Replace the integer value to change the time in seconds that controls how often 
 <key>StartInterval</key>
   <integer>300</integer>
 ```
-
-
-
 
 Then run:
 
@@ -149,15 +152,16 @@ launchctl load ~/Library/LaunchAgents/jofsync.plist
 To set it to run automatically.
 
 #### Running automatically with `cron`
+
 You can use crontab -e to edit your user crontab and create an entry like this:
 
 ```
 */10 * * * * cd ~/dev/git/jira-omnifocus/bin && ./jiraomnifocus.rb
 ```
 
-That should be it!  If it doesn't work, try adding some puts debug statements and running it manually.  
+That should be it! If it doesn't work, try adding some puts debug statements and running it manually.  
 I can't offer any support, as I don't know Ruby that well and just magically cobbled this together:)
 
 UPDATE:
 
-I have manually merged in some features from https://github.com/cgarrigues/jira-omnifocus as per discussion on https://github.com/devondragon/jira-omnifocus/pull/15   
+I have manually merged in some features from https://github.com/cgarrigues/jira-omnifocus as per discussion on https://github.com/devondragon/jira-omnifocus/pull/15

--- a/bin/jiraomnifocus.rb
+++ b/bin/jiraomnifocus.rb
@@ -31,6 +31,7 @@ omnifocus:
   inbox:    false      # Set 'true' if you want tasks in the Inbox instead of in a specific project.
   newproj:  false      # Set 'true' to add each JIRA ticket to OF as a Project instead of a Task.
   folder:   'Jira'     # Sets the OF folder where new Projects are created (only applies if 'newproj' is 'true').
+  descsync:  false     # Set 'true' if you want JIRA task descriptions synced to OF task notes
 EOS
   end
 
@@ -60,6 +61,7 @@ EOS
     opt :folder,  'OF Default Folder',  :type => :string,  :short => 'o', :required => false,   :default => config["omnifocus"]["folder"]
     opt :inbox,     'Create inbox tasks',  :type => :boolean,  :short => 'i', :required => false,   :default => config["omnifocus"]["inbox"]
     opt :newproj,  'Create as projects',  :type => :boolean,  :short => 'n', :required => false,   :default => config["omnifocus"]["newproj"]
+    opt :descsync,  'Sync Description to Notes',  :type => :boolean,  :short => 'd', :required => false,   :default => config["omnifocus"]["descsync"]
     opt :quiet,     'Disable output',       :type => :boolean,  :short => 'q',                       :default => true
   end
 end
@@ -269,7 +271,11 @@ def add_jira_tickets_to_omnifocus (omnifocus_document)
       puts "JOFSYNC.add_jira_tickets_to_omnifocus: created task_name: " + task_name
     end
     # Create the task notes with the Jira Ticket URL
-    task_notes = "#{$opts[:hostname]}/browse/#{jira_id}\n\n#{ticket["fields"]["description"]}"
+    if $opts[:descsync]
+      task_notes = "#{$opts[:hostname]}/browse/#{jira_id}\n\n#{ticket["fields"]["description"]}"
+    else
+      task_notes = "#{$opts[:hostname]}/browse/#{jira_id}\n"
+    end
 
     # Build properties for the Task
     @props = {}

--- a/jofsync.yaml.sample
+++ b/jofsync.yaml.sample
@@ -12,4 +12,5 @@ omnifocus:
   flag:     true       # Set this to 'true' if you want the new tasks to be flagged.
   inbox:    false      # Set 'true' if you want tasks in the Inbox instead of in a specific project.
   newproj:  false      # Set 'true' to add each JIRA ticket to OF as a Project instead of a Task.
+  descsync: false      # Set 'true' if you want JIRA task descriptions synced to OF task notes
   folder:   'Jira'     # Sets the OF folder where new Projects are created (only applies if 'newproj' is 'true').


### PR DESCRIPTION
Adding descsync option. This controls if the JIRA ticket description is synced to the OmniFocus Task Notes or not.  Default is false.