### PR TITLE
🔒 Fix password exposure in debug mode

### DIFF
--- a/bin/jiraomnifocus.rb
+++ b/bin/jiraomnifocus.rb
@@ -90,7 +90,7 @@ def get_issues
       $opts[:username] = keychainitem.account
       $opts[:password] = keychainitem.password
       if $DEBUG
-        puts "JOFSYNC.get_issues: username and password loaded from Keychain"
+        puts "JOFSYNC.get_issues: credentials loaded from Keychain"
       end
     else
       raise "Password for #{host} not found in keychain; add it using 'security add-internet-password -a <username> -s #{host} -w <password>'"
@@ -109,7 +109,6 @@ def get_issues
     # If the response was good, then grab the data
     if $DEBUG
       puts "JOFSYNC.get_issues: response code: " + response.code
-      puts "JOFSYNC.get_issues: response body: " + response.body
     end
     if response.code =~ /20[0-9]{1}/
       puts "Connected successfully to " + uri.hostname
@@ -340,7 +339,6 @@ def mark_resolved_jira_tickets_as_complete_in_omnifocus (omnifocus_document)
           response = http.request request
           if $DEBUG
             puts "JOFSYNC.mark_resolved_jira_tickets_as_complete_in_omnifocus: response code: " + response.code
-            puts "JOFSYNC.mark_resolved_jira_tickets_as_complete_in_omnifocus: response body: " + response.body
           end
           if response.code =~ /20[0-9]{1}/
             data = JSON.parse(response.body)


### PR DESCRIPTION
## Summary
Addresses the first critical security fix from fixes.md - removes password exposure in debug mode.

## Changes
- Remove explicit password mention from keychain debug message
- Eliminate JIRA API response body logging that could expose sensitive authentication tokens
- Maintain debugging functionality while protecting credentials

## Security Impact
- **Password exposure**: Debug mode no longer explicitly mentions passwords in log output  
- **Response body logging**: Eliminated logging of JIRA API response bodies which could contain sensitive authentication tokens, user email addresses, or other confidential data
- **Maintained debugging**: Still logs response codes for troubleshooting while protecting sensitive information

## Test Plan
- [x] Verify Ruby syntax is valid
- [x] Confirm debug messages no longer expose password information
- [x] Ensure response bodies are not logged in debug mode

Fixes: Critical security vulnerability in `bin/jiraomnifocus.rb:92-94` from fixes.md

🤖 Generated with [Claude Code](https://claude.ai/code)