### PR TITLE
🐛 Fix silent exception swallowing in JIRA sync

### DIFF
--- a/bin/jiraomnifocus.rb
+++ b/bin/jiraomnifocus.rb
@@ -401,7 +401,16 @@ def mark_resolved_jira_tickets_as_complete_in_omnifocus (omnifocus_document)
             raise StandardError, "Unsuccessful response code " + response.code + " for issue " + jira_id
           end
         end
-      rescue
+      rescue Net::HTTPError => e
+        puts "HTTP Error for JIRA #{jira_id}: #{e.message}"
+        puts e.backtrace.first(5).join("\n") if $DEBUG
+        next
+      rescue JSON::ParserError => e
+        puts "Failed to parse JIRA response for #{jira_id}: #{e.message}"
+        next
+      rescue StandardError => e
+        puts "Unexpected error processing #{jira_id}: #{e.class} - #{e.message}"
+        puts e.backtrace.first(10).join("\n") if $DEBUG
         next
       end
     end


### PR DESCRIPTION
## Summary
Addresses the second critical fix from fixes.md - replaces dangerous bare rescue with proper exception handling.

## Changes
- **Replace bare rescue**: Changed `rescue; next; end` to specific exception handling
- **HTTP Error handling**: Catches `Net::HTTPError` with detailed error messages including JIRA ticket ID
- **JSON parsing errors**: Specific handling for `JSON::ParserError` with context
- **Generic error handling**: `StandardError` catch-all with class name and message
- **Debug backtraces**: Include backtrace information when debug mode is enabled

## Security & Debugging Impact
- **No more silent failures**: Critical errors are now visible instead of being silently ignored
- **Better debugging**: Specific error messages help identify root causes
- **Context preservation**: Each error includes the JIRA ticket ID being processed
- **Backtrace support**: Debug mode shows stack traces for deeper troubleshooting

## Before vs After

**Before (dangerous)**:
```ruby
rescue
  next
end
```

**After (safe)**:
```ruby
rescue Net::HTTPError => e
  puts "HTTP Error for JIRA #{jira_id}: #{e.message}"
  puts e.backtrace.first(5).join("\n") if $DEBUG
  next
rescue JSON::ParserError => e
  puts "Failed to parse JIRA response for #{jira_id}: #{e.message}"
  next
rescue StandardError => e
  puts "Unexpected error processing #{jira_id}: #{e.class} - #{e.message}"
  puts e.backtrace.first(10).join("\n") if $DEBUG
  next
end
```

## Test Plan
- [x] Verify Ruby syntax is valid
- [x] Confirm specific exception types are properly handled
- [x] Ensure error messages include context (JIRA ticket ID)

Fixes: Critical debugging vulnerability in `bin/jiraomnifocus.rb:404` from fixes.md

🤖 Generated with [Claude Code](https://claude.ai/code)